### PR TITLE
add: ギフトリスト詳細画面・編集画面の作成

### DIFF
--- a/app/controllers/gift_lists_controller.rb
+++ b/app/controllers/gift_lists_controller.rb
@@ -3,6 +3,10 @@ class GiftListsController < ApplicationController
     @gift_lists = current_user.gift_lists.includes(:user)
   end
 
+  def show
+    @gift_list = current_user.gift_lists.find(params[:id])
+  end
+
   def new
     @gift_list = GiftList.new
   end

--- a/app/controllers/gift_lists_controller.rb
+++ b/app/controllers/gift_lists_controller.rb
@@ -1,11 +1,10 @@
 class GiftListsController < ApplicationController
+  before_action :set_gift_list, only: %i[ show edit update ]
   def index
     @gift_lists = current_user.gift_lists.includes(:user)
   end
 
-  def show
-    @gift_list = current_user.gift_lists.find(params[:id])
-  end
+  def show; end
 
   def new
     @gift_list = GiftList.new
@@ -19,7 +18,19 @@ class GiftListsController < ApplicationController
     end
   end
 
+  def edit; end
+
+  def update
+    if @gift_list.update(gift_lists_params)
+      redirect_to gift_lists_path(@gift_list)
+    end
+  end
+
   private
+
+  def set_gift_list
+    @gift_list = current_user.gift_lists.find(params[:id])
+  end
 
   def gift_lists_params
     params.require(:gift_list).permit(:recipient_name, :purpose)

--- a/app/views/gift_lists/_form.html.erb
+++ b/app/views/gift_lists/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with model: gift_list do |f| %>
+  <fieldset class="fieldset bg-base-200 border-base-300 rounded-box w-xs border p-4">
+
+    <label class="label">ギフトを贈る方の名前*</label>
+    <div class="input">
+      <%= f.text_field :recipient_name, autofocus: true, autocomplete: "recipient_name", placeholder: "敬称略で入力" %>
+    </div>
+
+    <label class="label">贈る用途</label>
+    <div class="input">
+      <%= f.text_field :purpose, autocomplete: "purpose", placeholder: "例：誕生日祝い" %>
+    </div>
+
+    <button class="btn btn-neutral mt-4">
+      <%= f.submit "ギフトリストを作成" %>
+    </button>
+
+  </fieldset>
+<% end %>
+<%= link_to "戻る", root_path %>

--- a/app/views/gift_lists/_gift_list.html.erb
+++ b/app/views/gift_lists/_gift_list.html.erb
@@ -1,0 +1,4 @@
+<ul class="menu">
+  <li><%= link_to gift_list_path(gift_list)  do %><strong class="md:font-bold"><%= "#{gift_list.recipient_name}"%></strong>さんへ贈る
+    <strong class="text-left"><%= "#{gift_list.purpose.presence || 'ギフトリスト'}" %></strong><% end %></li>
+</ul>

--- a/app/views/gift_lists/edit.html.erb
+++ b/app/views/gift_lists/edit.html.erb
@@ -1,0 +1,2 @@
+<h2 class="text-3xl font-bold">ギフトリストを編集</h2>
+  <%= render "form", gift_list: @gift_list %>

--- a/app/views/gift_lists/index.html.erb
+++ b/app/views/gift_lists/index.html.erb
@@ -1,21 +1,15 @@
 <div class="">
 <h2 class="text-3xl font-bold">ギフトリスト一覧</h2>
-<!-- ギフトリスト一覧 -->
 
   <% if @gift_lists.present? %>
-    <ul class="menu">
-      <% @gift_lists.each do |gl| %>
-        <li>
-          <%= link_to @url do %><strong class="md:font-bold"><%= "#{gl.recipient_name}"%></strong>さんへ贈る
-          <strong class="text-left"><%= "#{gl.purpose.presence || 'ギフトリスト'}" %></strong><% end %>
-        </li>
-      <% end %>
-    </ul>
+    <%= render @gift_lists %>
   <% else %>
     <div class="">
       ギフトリストはまだありません<br>
       ギフトリストを作成しましょう！
     </div>
   <% end %>
+
+  
 
 </div>

--- a/app/views/gift_lists/new.html.erb
+++ b/app/views/gift_lists/new.html.erb
@@ -1,22 +1,2 @@
 <h2 class="text-3xl font-bold">ギフトリストを作成</h2>
-
-<%= form_with model: @gift_list do |f| %>
-  <fieldset class="fieldset bg-base-200 border-base-300 rounded-box w-xs border p-4">
-
-    <label class="label">ギフトを贈る方の名前*</label>
-    <div class="input">
-      <%= f.text_field :recipient_name, autofocus: true, autocomplete: "recipient_name", placeholder: "敬称略で入力" %>
-    </div>
-
-    <label class="label">贈る用途</label>
-    <div class="input">
-      <%= f.text_field :purpose, autocomplete: "purpose", placeholder: "例：誕生日祝い" %>
-    </div>
-
-    <button class="btn btn-neutral mt-4">
-      <%= f.submit "ギフトリストを作成" %>
-    </button>
-
-  </fieldset>
-  <%= link_to "戻る", root_path %>
-<% end %>
+  <%= render "form", gift_list: @gift_list %>

--- a/app/views/gift_lists/show.html.erb
+++ b/app/views/gift_lists/show.html.erb
@@ -1,0 +1,7 @@
+<div class="">
+  <h2 class="text-xl font-bold">
+    <%= "#{@gift_list.recipient_name}"%>さんへ贈る<br>
+    <%= "#{@gift_list.purpose.presence || 'ギフトリスト'}" %>
+  </h2>
+  <%= link_to "タイトルの編集", "#", {class: "text-sm"}%>
+</div>

--- a/app/views/gift_lists/show.html.erb
+++ b/app/views/gift_lists/show.html.erb
@@ -3,5 +3,5 @@
     <%= "#{@gift_list.recipient_name}"%>さんへ贈る<br>
     <%= "#{@gift_list.purpose.presence || 'ギフトリスト'}" %>
   </h2>
-  <%= link_to "タイトルの編集", "#", {class: "text-sm"}%>
+  <%= link_to "タイトルの編集", edit_gift_list_path, {class: "text-sm"}%>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  resources :gift_lists, only: %i[ index new create show ]
+  resources :gift_lists, only: %i[ index new create show edit update ]
 
   # トップページ
   root "static_pages#top"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  resources :gift_lists, only: %i[ index new create ]
+  resources :gift_lists, only: %i[ index new create show ]
 
   # トップページ
   root "static_pages#top"


### PR DESCRIPTION
Closes https://github.com/Mari-st-11/catalog-gift-maker/issues/17
Closes https://github.com/Mari-st-11/catalog-gift-maker/issues/18

## 概要
ギフトリスト詳細画面・編集画面を作成しました

## やったこと
- `gift_lists_controller.rb`に`show`、`edit`、'update'アクションを追加
- `gift_lists_controller.rb`に`set_gift_list`アクションを追加し、show edit update事前にパラメーターを読み込むようにしました
- `routes.rb`にルーティング追加
- 編集画面(edit.html.erb)の作成
- ギフトリスト一覧から詳細画面へ飛ぶリンクを追加
- 詳細画面に編集画面へ飛ぶリンクを追加

## やらないこと
- 見た目の作り込み
- 未ログインでヘッダーリンク「ギフトリスト一覧」を押した際に出るエラー画面の対処
- ギフトアイテムの表示
- 「アイテムを追加」「ギフトを贈る」ボタンの表示

## できるようになること（ユーザ目線）
- ギフトリスト一覧から、詳細ページへ飛べるように
- ギフトリストの表示名の編集ができるように

## できなくなること（ユーザ目線）
特にありません

## 動作確認
http://localhost:3000/のヘッダーの「ギフトリスト一覧」のリンクから確認できます

## その他
特にありません