### PR TITLE
add: OGP情報の取得

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,5 @@ gem "tailwindcss-rails", "~> 4.2.3", github: "rails/tailwindcss-rails", branch: 
 gem "devise"
 
 gem "draper", "4.0.2"
+
+gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,10 +130,21 @@ GEM
     drb (2.2.1)
     erb (5.0.1)
     erubi (1.13.1)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -158,6 +169,9 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (5.2.0)
+      benchmark
+      logger
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -284,6 +298,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.4)
+      ffi (~> 1.12)
+      logger
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     securerandom (0.4.1)
@@ -356,6 +373,7 @@ DEPENDENCIES
   debug
   devise
   draper (= 4.0.2)
+  image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
   nokogiri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,6 +358,7 @@ DEPENDENCIES
   draper (= 4.0.2)
   jbuilder
   jsbundling-rails
+  nokogiri
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.0)

--- a/app/controllers/gift_items_controller.rb
+++ b/app/controllers/gift_items_controller.rb
@@ -12,8 +12,9 @@ class GiftItemsController < ApplicationController
 
     @gift_item.name = doc.css('meta[property="og:title"] @content').to_s
     @gift_item.description = doc.css('meta[property="og:description"] @content').to_s
-    @gift_item.image = doc.css('meta[property="og:image"] @content').to_s
-    
+    image = doc.css('meta[property="og:image"] @content').to_s
+    @gift_item.image.attach(io: URI.open(image), filename: image)
+
     if @gift_item.save
       redirect_to root_path
     end

--- a/app/controllers/gift_items_controller.rb
+++ b/app/controllers/gift_items_controller.rb
@@ -4,7 +4,16 @@ class GiftItemsController < ApplicationController
   end
 
   def create
+    require 'open-uri'
     @gift_item = current_user.gift_items.build(gift_item_params)
+
+    html = URI.open(@gift_item.url).read
+    doc = Nokogiri::HTML.parse(html)
+
+    @gift_item.name = doc.css('meta[property="og:title"] @content').to_s
+    @gift_item.description = doc.css('meta[property="og:description"] @content').to_s
+    @gift_item.image = doc.css('meta[property="og:image"] @content').to_s
+    
     if @gift_item.save
       redirect_to root_path
     end

--- a/app/models/gift_item.rb
+++ b/app/models/gift_item.rb
@@ -4,6 +4,8 @@ class GiftItem < ApplicationRecord
   validates :description, length: { maximum: 225 }
   enum :status, { unchoice: 0, choice: 1 }
 
+  has_one_attached :image
+
   belongs_to :user
   belongs_to :gift_list
 end

--- a/app/views/gift_items/_new_form.html.erb
+++ b/app/views/gift_items/_new_form.html.erb
@@ -5,7 +5,7 @@
     <div class="input">
       <%= f.text_field :url, autofocus: true, autocomplete: "url", placeholder: "http://〜" %>
     </div>
-
+<!--
     <label class="label">商品名</label>
     <div class="input">
       <%= f.text_field :name, autocomplete: "name", placeholder: "コーヒーメーカー" %>
@@ -20,7 +20,7 @@
     <div class="input">
       <%= f.text_field :image, autocomplete: "image", placeholder: "画像URL" %>
     </div>
-
+-->
     <button class="btn btn-neutral mt-4">
       <%= f.submit "ギフトを登録" %>
     </button>

--- a/db/migrate/20250610155315_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250610155315_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_04_082332) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_10_155315) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "gift_items", force: :cascade do |t|
     t.text "url"
@@ -53,6 +81,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_04_082332) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "gift_items", "gift_lists"
   add_foreign_key "gift_items", "users"
   add_foreign_key "gift_lists", "users"


### PR DESCRIPTION
closed #19
closed #20 

## 概要
OGP情報の取得

## やったこと
- `gem Nokogiri`のインストール
- `ActiveStorage``image_processing`のインストール
- 商品URLを入力すると、商品名、商品説明、商品画像のOGP情報を取得して保存する
- 画像はActiveStorageと紐付け、画像を保存して表示

## やらないこと
- 画像の差し替え（別issue）

## できるようになること（ユーザ目線）
- 商品URLを入力したら、自動で商品名、説明、画像が取得・表示される。

## できなくなること（ユーザ目線）
特にありません

## 動作確認
http://localhost:3000/gift_lists/1/gift_items/new

## その他
特にありません
