### PR TITLE
Feature/giftitem edit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,11 +58,10 @@ end
 
 gem "tailwindcss-rails", "~> 4.2.3", github: "rails/tailwindcss-rails", branch: "main"
 
-
 gem "devise"
 
 gem "draper", "4.0.2"
 
 gem "nokogiri"
 
-gem 'pry-rails'
+gem "pry-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,5 @@ gem "devise"
 gem "draper", "4.0.2"
 
 gem "nokogiri"
+
+gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -169,6 +170,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    method_source (1.1.0)
     mini_magick (5.2.0)
       benchmark
       logger
@@ -211,6 +213,11 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.4.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
     psych (5.2.6)
       date
       stringio
@@ -378,6 +385,7 @@ DEPENDENCIES
   jsbundling-rails
   nokogiri
   pg (~> 1.1)
+  pry-rails
   puma (>= 5.0)
   rails (~> 7.2.0)
   rubocop-rails-omakase

--- a/app/controllers/gift_items_controller.rb
+++ b/app/controllers/gift_items_controller.rb
@@ -1,6 +1,5 @@
 class GiftItemsController < ApplicationController
   before_action :set_gift_item, only: %i[ show edit update ]
-  before_action :set_gift_list, only: %i[ show edit update ]
 
   def new
     @gift_item = GiftItem.new
@@ -39,9 +38,6 @@ class GiftItemsController < ApplicationController
     params.require(:gift_item).permit(:url, :name, :description, :image).merge(gift_list_id: params[:gift_list_id])
   end
   
-  def set_gift_list
-    @gift_list = current_user.gift_lists.find(params[:id])
-  end
 
   def gift_item_params_update
     params.require(:gift_item).permit(:url, :name, :description)

--- a/app/controllers/gift_items_controller.rb
+++ b/app/controllers/gift_items_controller.rb
@@ -1,5 +1,7 @@
 class GiftItemsController < ApplicationController
   before_action :set_gift_item, only: %i[ show edit update ]
+  before_action :set_gift_list, only: %i[ show edit update ]
+
   def new
     @gift_item = GiftItem.new
   end
@@ -26,7 +28,7 @@ class GiftItemsController < ApplicationController
   def edit; end
 
   def update
-    if @gift_item.update(gift_item_params)
+    if @gift_item.update(gift_item_params_update)
       redirect_to gift_item_path(@gift_item)
     end
   end
@@ -35,6 +37,14 @@ class GiftItemsController < ApplicationController
 
   def gift_item_params
     params.require(:gift_item).permit(:url, :name, :description, :image).merge(gift_list_id: params[:gift_list_id])
+  end
+  
+  def set_gift_list
+    @gift_list = current_user.gift_lists.find(params[:id])
+  end
+
+  def gift_item_params_update
+    params.require(:gift_item).permit(:url, :name, :description)
   end
 
   def set_gift_item

--- a/app/controllers/gift_items_controller.rb
+++ b/app/controllers/gift_items_controller.rb
@@ -6,7 +6,7 @@ class GiftItemsController < ApplicationController
   end
 
   def create
-    require 'open-uri'
+    require "open-uri"
     @gift_item = current_user.gift_items.build(gift_item_params)
 
     html = URI.open(@gift_item.url).read
@@ -37,7 +37,6 @@ class GiftItemsController < ApplicationController
   def gift_item_params
     params.require(:gift_item).permit(:url, :name, :description, :image).merge(gift_list_id: params[:gift_list_id])
   end
-  
 
   def gift_item_params_update
     params.require(:gift_item).permit(:url, :name, :description)
@@ -46,5 +45,4 @@ class GiftItemsController < ApplicationController
   def set_gift_item
     @gift_item = current_user.gift_items.find(params[:id])
   end
-
 end

--- a/app/controllers/gift_items_controller.rb
+++ b/app/controllers/gift_items_controller.rb
@@ -1,4 +1,5 @@
 class GiftItemsController < ApplicationController
+  before_action :set_gift_item, only: %i[ show edit update ]
   def new
     @gift_item = GiftItem.new
   end
@@ -20,9 +21,24 @@ class GiftItemsController < ApplicationController
     end
   end
 
+  def show; end
+
+  def edit; end
+
+  def update
+    if @gift_item.update(gift_item_params)
+      redirect_to gift_item_path(@gift_item)
+    end
+  end
+
   private
 
   def gift_item_params
     params.require(:gift_item).permit(:url, :name, :description, :image).merge(gift_list_id: params[:gift_list_id])
   end
+
+  def set_gift_item
+    @gift_item = current_user.gift_items.find(params[:id])
+  end
+
 end

--- a/app/models/gift_item.rb
+++ b/app/models/gift_item.rb
@@ -1,7 +1,6 @@
 class GiftItem < ApplicationRecord
-  validates :url, presence: true, unless: :name?, length: { maximum: 535 }
+  validates :url, presence: true, unless: :name?
   validates :name, length: { maximum: 225 }, presence: true, unless: :url?
-  validates :description, length: { maximum: 225 }
   enum :status, { unchoice: 0, choice: 1 }
 
   has_one_attached :image

--- a/app/views/gift_items/_gift_item.html.erb
+++ b/app/views/gift_items/_gift_item.html.erb
@@ -1,10 +1,10 @@
-<%= link_to "#" do %>
+<%= link_to gift_item_path(gift_item) do %>
   <div class="card w-96 bg-base-100 card-sm shadow-sm">
     <figure>
       <%= image_tag gift_item.image.presence || "https://placehold.jp/400x300.png?text=sample" %>
     </figure>
     <div class="card-body">
-      <h2 class="card-title"><%= "#{gift_item.name}"%></h2>
+      <h2 class="card-title"><%= gift_item.name %></h2>
       <div class="card-actions justify-end text-right">
         <p class="underline">ギフトの詳細を見る ></p>
       </div>

--- a/app/views/gift_items/edit.html.erb
+++ b/app/views/gift_items/edit.html.erb
@@ -1,19 +1,14 @@
 <%= form_with model: @gift_item do |f| %>
   <fieldset class="fieldset bg-base-200 border-base-300 rounded-box w-xs border p-4">
 
-    <label class="label">商品URL</label>
-    <div class="input">
-      <%= f.text_field :url, autofocus: true, autocomplete: "url", placeholder: "http://〜" %>
-    </div>
-
     <label class="label">商品名</label>
     <div class="input">
       <%= f.text_field :name, autocomplete: "name", placeholder: "コーヒーメーカー" %>
     </div>
     
     <label class="label">商品説明</label>
-    <div class="input">
-      <%= f.text_field :description, autocomplete: "description", placeholder: "電動ミル付きのコーヒーメーカーです" %>
+    <div class="textarea textarea-border max-w-none resize-none">
+      <%= f.text_area :description, autocomplete: "description", placeholder: "電動ミル付きのコーヒーメーカーです", size: "34x10"%>
     </div>
 <!--
     <label class="label">商品画像</label>

--- a/app/views/gift_items/edit.html.erb
+++ b/app/views/gift_items/edit.html.erb
@@ -1,0 +1,29 @@
+<%= form_with model: @gift_item do |f| %>
+  <fieldset class="fieldset bg-base-200 border-base-300 rounded-box w-xs border p-4">
+
+    <label class="label">商品URL</label>
+    <div class="input">
+      <%= f.text_field :url, autofocus: true, autocomplete: "url", placeholder: "http://〜" %>
+    </div>
+
+    <label class="label">商品名</label>
+    <div class="input">
+      <%= f.text_field :name, autocomplete: "name", placeholder: "コーヒーメーカー" %>
+    </div>
+    
+    <label class="label">商品説明</label>
+    <div class="input">
+      <%= f.text_field :description, autocomplete: "description", placeholder: "電動ミル付きのコーヒーメーカーです" %>
+    </div>
+<!--
+    <label class="label">商品画像</label>
+    <div class="input">
+      <%= f.text_field :image, autocomplete: "image", placeholder: "画像URL" %>
+    </div>
+-->
+    <button class="btn btn-neutral mt-4">
+      <%= f.submit "ギフトを編集" %>
+    </button>
+
+  </fieldset>
+<% end %>

--- a/app/views/gift_items/show.html.erb
+++ b/app/views/gift_items/show.html.erb
@@ -1,10 +1,12 @@
 <div class="">
   <h2 class="text-xl font-bold">
-
+    <%= @gift_list.recipient_name %>さんへ贈る<br>
+    <%= @gift_list.purpose.presence || "ギフトリスト" %>
   </h2>
   <%= link_to "ギフトの編集", edit_gift_item_path, {class: "text-sm"} %>
 
   <%= image_tag @gift_item.image.presence || "https://placehold.jp/400x300.png?text=sample" %>
   <h2 class="card-title"><%= @gift_item.name %></h2>
   <p class=""><%= @gift_item.description %></p>
+  <%= link_to "< 一覧へ戻る", gift_list_path(@gift_list), {class: "text-sm"} %>
 </div>

--- a/app/views/gift_items/show.html.erb
+++ b/app/views/gift_items/show.html.erb
@@ -1,12 +1,12 @@
 <div class="">
   <h2 class="text-xl font-bold">
-    <%= @gift_list.recipient_name %>さんへ贈る<br>
-    <%= @gift_list.purpose.presence || "ギフトリスト" %>
+    <%= @gift_item.gift_list.recipient_name %>さんへ贈る<br>
+    <%= @gift_item.gift_list.purpose.presence || "ギフトリスト" %>
   </h2>
   <%= link_to "ギフトの編集", edit_gift_item_path, {class: "text-sm"} %>
 
   <%= image_tag @gift_item.image.presence || "https://placehold.jp/400x300.png?text=sample" %>
   <h2 class="card-title"><%= @gift_item.name %></h2>
   <p class=""><%= @gift_item.description %></p>
-  <%= link_to "< 一覧へ戻る", gift_list_path(@gift_list), {class: "text-sm"} %>
+  <%= link_to "< 一覧へ戻る", gift_list_path(@gift_item.gift_list), {class: "text-sm"} %>
 </div>

--- a/app/views/gift_items/show.html.erb
+++ b/app/views/gift_items/show.html.erb
@@ -1,0 +1,10 @@
+<div class="">
+  <h2 class="text-xl font-bold">
+
+  </h2>
+  <%= link_to "ギフトの編集", edit_gift_item_path, {class: "text-sm"} %>
+
+  <%= image_tag @gift_item.image.presence || "https://placehold.jp/400x300.png?text=sample" %>
+  <h2 class="card-title"><%= @gift_item.name %></h2>
+  <p class=""><%= @gift_item.description %></p>
+</div>

--- a/app/views/gift_lists/edit.html.erb
+++ b/app/views/gift_lists/edit.html.erb
@@ -1,2 +1,2 @@
-<h2 class="text-3xl font-bold">ギフトリストを編集</h2>
+<h2 class="text-3xl font-bold">ギフトリスト名を編集</h2>
   <%= render "form", gift_list: @gift_list %>

--- a/app/views/gift_lists/show.html.erb
+++ b/app/views/gift_lists/show.html.erb
@@ -1,7 +1,7 @@
 <div class="">
   <h2 class="text-xl font-bold">
-    <%= "#{@gift_list.recipient_name}"%>さんへ贈る<br>
-    <%= "#{@gift_list.purpose.presence || 'ギフトリスト'}" %>
+    <%= @gift_list.recipient_name %>さんへ贈る<br>
+    <%= @gift_list.purpose.presence || "ギフトリスト" %>
   </h2>
   <%= link_to "タイトルの編集", edit_gift_list_path, {class: "text-sm"} %>
   <%= link_to "ギフトを追加", new_gift_list_gift_item_path(@gift_list.id), {class: "btn btn-neutral mt-4"} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,8 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   resources :gift_lists, only: %i[ index new create show edit update ] do
-    resources :gift_items, only: %i[ create new edit show update ], shallow: true
+    resources :gift_items, only: %i[ new create show edit update ], shallow: true
   end
-
 
   # トップページ
   root "static_pages#top"


### PR DESCRIPTION
closed #21

## 概要
ギフトアイテム編集画面の作成

## やったこと
- ギフトアイテム一覧から、ギフトアイテム詳細画面へ遷移
- 詳細画面から商品名と商品画像の編集が可能

## やらないこと
- 画像の差し替え（別issue）

## できるようになること（ユーザ目線）
- ギフトアイテムの修正が可能に

## できなくなること（ユーザ目線）
特にありません

## 動作確認
http://localhost:3000/gift_items/1/edit

## その他
特にありません
