### PR TITLE
update: ギフトが選択後、ギフトリストに選択されたアイテムを表示

### DIFF
--- a/app/controllers/gift_lists_controller.rb
+++ b/app/controllers/gift_lists_controller.rb
@@ -1,11 +1,12 @@
 class GiftListsController < ApplicationController
   before_action :set_gift_list, only: %i[ show edit update ]
   def index
-    @gift_lists = current_user.gift_lists.includes(:user)
+    @gift_lists = current_user.gift_lists.includes(:user).order(:id)
   end
 
   def show
-    @gift_items = @gift_list.gift_items.includes(:user)
+    @gift_items = @gift_list.gift_items.includes(:user).order(:id)
+    @selected_gift_item = @gift_list.gift_items.where(status: [ :selected ]).first
   end
 
   def new

--- a/app/controllers/shared_gift_lists_controller.rb
+++ b/app/controllers/shared_gift_lists_controller.rb
@@ -8,19 +8,14 @@ class SharedGiftListsController < ApplicationController
 
   def choose
     @selected_gift_item = @gift_list.gift_items.find(params[:gift_item_id])
-    puts "ギフトid: #{@selected_gift_item.id}が選択されました"
+    # 選択されたアイテムのstatusをselectedに変更
     @selected_gift_item.selected!
 
     @unselected_gift_items = @gift_list.gift_items.where.not(id: params[:gift_item_id])
-
+    # 選択されなかったアイテムのstatusをunselectedに変更
     @unselected_gift_items.each do |unselected_gift_item|
-      puts "#{unselected_gift_item.id}の状態は#{unselected_gift_item.status}です"
       unselected_gift_item.unselected!
     end
-    
-    puts "状態は#{@selected_gift_item.status}です"
-
-    # redirect_to action: :show
   end
 
   private

--- a/app/views/gift_items/show.html.erb
+++ b/app/views/gift_items/show.html.erb
@@ -8,5 +8,8 @@
   <%= image_tag @gift_item.image.presence || "https://placehold.jp/400x300.png?text=sample" %>
   <h2 class="card-title"><%= @gift_item.name %></h2>
   <p class=""><%= @gift_item.description %></p>
+  <% if @gift_item.url.present? %>
+    <%= link_to "ギフトを購入する", @gift_item.url, target: "_blank", rel: "noopener", class: "btn" %>
+  <% end %>
   <%= link_to "< 一覧へ戻る", gift_list_path(@gift_item.gift_list), {class: "text-sm"} %>
 </div>

--- a/app/views/gift_lists/show.html.erb
+++ b/app/views/gift_lists/show.html.erb
@@ -3,9 +3,20 @@
     <%= @gift_list.recipient_name %>さんへ贈る<br>
     <%= @gift_list.purpose.presence || "ギフトリスト" %>
   </h2>
-  <%= link_to "タイトルの編集", edit_gift_list_path, {class: "text-sm"} %>
-  <%= link_to "ギフトを追加", new_gift_list_gift_item_path(@gift_list.id), {class: "btn btn-neutral mt-4"} %>
-
+  <%= link_to "タイトルの編集", edit_gift_list_path, class: "text-sm" %>
+  <%= link_to "ギフトを追加", new_gift_list_gift_item_path(@gift_list.id), class: "btn btn-neutral mt-4" %>
+  <p>シェア用のURLはこちら ⇨ https://catalog-gift-maker.onrender.com/shared_gift_lists/<%= @gift_list.id %>/</p>
+    <% if @selected_gift_item.present? %>
+      <div>
+      <b><%= @gift_list.recipient_name %>さんが選んだギフト<br></b>
+      早速購入して贈りましょう！
+      <%= image_tag @selected_gift_item.image.presence || "https://placehold.jp/100x100.png?text=sample", :width => "100" %>
+      <%= @selected_gift_item.name %>
+      <% if @selected_gift_item.url.present? %>
+        <%= link_to "ギフトを購入する", @selected_gift_item.url, target: "_blank", rel: "noopener", class: "btn" %>
+      <% end %>
+      </div>
+    <% end %>
     <% if @gift_items.present? %>
       <%= render @gift_items %>
     <% else %>


### PR DESCRIPTION
closed #30

## 概要
ギフト選択後のギフトリスト画面の修正

## やったこと
- 選択されたギフトを表示
- 保持していた商品ページURLを使用して、購入ページへリンクボタンを設置
- シェア用URLを表示

## やらないこと
- シェア用URLをボタンを押した後に表示させること
- シェア用URLのコピーボタン

## できるようになること（ユーザ目線）
- リストを贈った相手が選択したアイテムがわかるようになる

## できなくなること（ユーザ目線）
特にありません

## 動作確認
http://localhost:3000/gift_lists/1/

## その他
特にありません
