### PR TITLE
add:シェア用ギフトアイテム詳細画面の作成

### DIFF
--- a/app/controllers/gift_items_controller.rb
+++ b/app/controllers/gift_items_controller.rb
@@ -1,11 +1,12 @@
 class GiftItemsController < ApplicationController
   before_action :set_gift_item, only: %i[ show edit update destroy ]
+  before_action :set_gift_list, only: %i[ new ]
 
   def new
     @gift_item = GiftItem.new
   end
 
-  def create
+  def createbv 
     require "open-uri"
     require "nokogiri"
 
@@ -41,7 +42,6 @@ class GiftItemsController < ApplicationController
   end
 
   def destroy
-    # @gift_list = GiftList.find(params[:id])
     @gift_item.destroy!
     redirect_to gift_lists_path
   end
@@ -58,5 +58,9 @@ class GiftItemsController < ApplicationController
 
   def set_gift_item
     @gift_item = current_user.gift_items.find(params[:id])
+  end
+
+  def set_gift_list
+    @gift_list = GiftList.find(params[:gift_list_id])
   end
 end

--- a/app/controllers/gift_lists_controller.rb
+++ b/app/controllers/gift_lists_controller.rb
@@ -17,7 +17,7 @@ class GiftListsController < ApplicationController
     @gift_list = current_user.gift_lists.build(gift_list_params)
 
     if @gift_list.save
-      redirect_to gift_lists_path(@gift_list)
+      redirect_to gift_list_path(@gift_list)
     end
   end
 

--- a/app/controllers/shared_gift_items_controller.rb
+++ b/app/controllers/shared_gift_items_controller.rb
@@ -1,0 +1,6 @@
+class SharedGiftListsController < ApplicationController
+  def show
+    @gift_item = GiftList.gift_items.find(params[:id])
+    
+  end
+end

--- a/app/controllers/shared_gift_items_controller.rb
+++ b/app/controllers/shared_gift_items_controller.rb
@@ -1,6 +1,6 @@
-class SharedGiftListsController < ApplicationController
+class SharedGiftItemsController < ApplicationController
   def show
-    @gift_item = GiftList.gift_items.find(params[:id])
-    
+    #@gift_list = GiftList.find(params[:id])
+    @gift_item = GiftItem.find(params[:id])
   end
 end

--- a/app/models/gift_item.rb
+++ b/app/models/gift_item.rb
@@ -3,7 +3,6 @@ class GiftItem < ApplicationRecord
   validates :name, length: { maximum: 225 }, presence: true, unless: :url?
   enum :status, { unselected: 0, selected: 1 }
   mount_uploader :image, ImageUploader
-  #has_one_attached :image
 
   belongs_to :user
   belongs_to :gift_list

--- a/app/views/gift_items/_selected_button.html.erb
+++ b/app/views/gift_items/_selected_button.html.erb
@@ -1,1 +1,1 @@
-<div class="btn mt-4">選択済み</div>
+<div class="btn mt-4">このギフトを選びました</div>

--- a/app/views/gift_items/_shared_gift_item.html.erb
+++ b/app/views/gift_items/_shared_gift_item.html.erb
@@ -7,7 +7,7 @@
       <% end %>
     </figure>
     <div class="card-body">
-      <h2 class="card-title"><%= gift_item.id %><%= gift_item.name %></h2>
+      <h2 class="card-title"><%= gift_item.name %></h2>
       <div class="card-actions justify-end text-right">
         <%= link_to shared_gift_item_path(gift_item) do %><p class="underline">ギフトの詳細を見る ></p><% end %>
         <div id="select_button_<%= gift_item.id %>">

--- a/app/views/gift_items/_shared_gift_item.html.erb
+++ b/app/views/gift_items/_shared_gift_item.html.erb
@@ -2,14 +2,14 @@
 <div class="flex items-stretch h-full">
   <div class="card w-96 bg-base-100 card-sm shadow-sm">
     <figure>
-      <%= link_to gift_item_path(gift_item) do %>
+      <%= link_to shared_gift_item_path(gift_item) do %>
         <%= image_tag gift_item.image.url.presence %>
       <% end %>
     </figure>
     <div class="card-body">
       <h2 class="card-title"><%= gift_item.id %><%= gift_item.name %></h2>
       <div class="card-actions justify-end text-right">
-        <%= link_to gift_item_path(gift_item) do %><p class="underline">ギフトの詳細を見る ></p><% end %>
+        <%= link_to shared_gift_item_path(gift_item) do %><p class="underline">ギフトの詳細を見る ></p><% end %>
         <div id="select_button_<%= gift_item.id %>">
           <%= render(gift_item.selected? ? "gift_items/selected_button" : "gift_items/unselected_button", gift_item: gift_item) %>
         </div>

--- a/app/views/gift_items/edit.html.erb
+++ b/app/views/gift_items/edit.html.erb
@@ -24,4 +24,5 @@
 
     </fieldset>
   <% end %>
+
 </div>

--- a/app/views/gift_items/new.html.erb
+++ b/app/views/gift_items/new.html.erb
@@ -1,4 +1,5 @@
 <div class="container mx-auto px-5 py-10 text-center">
   <h1 class="text-xl font-bold mb-5">ギフトを登録</h1>
   <%= render "new_form", gift_item: @gift_item %>
+  <%= link_to "< ギフト一覧へ戻る", gift_list_path(@gift_list), class: "link" %>
 </div>

--- a/app/views/gift_lists/_form.html.erb
+++ b/app/views/gift_lists/_form.html.erb
@@ -13,10 +13,9 @@
     </div>
 
     <button class="btn btn-neutral mt-4">
-      <%= f.submit "ギフトリストを作成" %>
+      <%= f.submit "ギフトリストを登録" %>
     </button>
 
   </fieldset>
 <% end %>
-<%= link_to "戻る", root_path %>
 </div>

--- a/app/views/gift_lists/edit.html.erb
+++ b/app/views/gift_lists/edit.html.erb
@@ -3,4 +3,5 @@
   <div class="mx-auto">
   <%= render "form", gift_list: @gift_list %>
   </div>
+  <%= link_to "< ギフト一覧へ戻る", gift_list_path(@gift_list), class: "link" %>
 </div>

--- a/app/views/gift_lists/new.html.erb
+++ b/app/views/gift_lists/new.html.erb
@@ -1,4 +1,5 @@
 <div class="container mx-auto px-5 py-10 text-center">
   <h1 class="text-xl font-bold mb-5">ギフトリストを作成</h1>
   <%= render "form", gift_list: @gift_list %>
+  <%= link_to "< ギフトリスト一覧へ戻る", gift_lists_path, class: "link" %>
 </div>

--- a/app/views/gift_lists/show.html.erb
+++ b/app/views/gift_lists/show.html.erb
@@ -5,7 +5,9 @@
   </h1>
   <div><%= link_to "リスト名を編集", edit_gift_list_path, class: "text-sm" %></div>
   <%= link_to "ギフトを追加", new_gift_list_gift_item_path(@gift_list.id), class: "btn btn-neutral mt-4" %>
-  <p class="m-4">シェア用のURLはこちら　https://catalog-gift-maker.onrender.com/shared_gift_lists/<%= @gift_list.id %>/</p>
+  <% if @gift_items.present? %>
+    <p class="m-4">シェア用のURLはこちら　https://catalog-gift-maker.onrender.com/shared_gift_lists/<%= @gift_list.id %>/</p>
+  <% end %>
 
     <% if @selected_gift_item.present? %>
     <div class="w-4">
@@ -31,8 +33,9 @@
       <%= render @gift_items %>
       </div>
     <% else %>
-      <div class="">
+      <div class="p-5">
         登録されたギフトがありません
       </div>
     <% end %>
+  <%= link_to "< ギフトリスト一覧へ戻る", gift_lists_path, class: "link" %>
 </div>

--- a/app/views/shared_gift_items/show.html.erb
+++ b/app/views/shared_gift_items/show.html.erb
@@ -1,0 +1,14 @@
+<div class="container mx-auto px-5 py-10 text-center">
+  <h1 class="text-xl font-bold mb-5">
+    <%= @gift_item.gift_list.recipient_name %>さんへ贈る<br>
+    <%= @gift_item.gift_list.purpose.presence || "ギフトリスト" %>
+  </h1>
+
+  <div class="w-[90%] max-w-[500px] mx-auto bg-white p-4">
+  <%= image_tag @gift_item.image.url.presence, class: "w-full h-auto mb-4" %>
+  <h2 class="card-title mb-4"><%= @gift_item.name %></h2>
+  <p class="mb-4 text-left text-sm/6"><%= @gift_item.description %></p>
+  <div class="mt-3">
+    <%= link_to "< 一覧へ戻る", shared_gift_list_path(@gift_item.gift_list), {class: "text-sm"} %>
+  </div>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -198,7 +198,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     member do
       post :choose
     end
-    resources :shared_gift_items, only: %i[ show ]
+    resources :shared_gift_items, only: %i[ show ], shallow: true
   end
 
   # トップページ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     member do
       post :choose
     end
+    resources :shared_gift_items, only: %i[ show ]
   end
 
   # トップページ


### PR DESCRIPTION
closed #84

## 概要
シェア用ギフトアイテム詳細画面の作成

## やったこと
- シェア用画面で、ギフトアイテムの詳細画面を作成
- 全体的に「戻る」リンクの遷移先を調整

## やらないこと
特にありません

## できるようになること（ユーザ目線）
- 贈られた相手がギフト詳細を見ることができる

## できなくなること（ユーザ目線）
特にありません

## 動作確認
http://localhost:3000/shared_gift_item/1/

## その他
特にありません
